### PR TITLE
Add testimonials, FAQ, and final CTA sections to landing page

### DIFF
--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -190,6 +190,10 @@ a {
   flex: 1 1 auto;
 }
 
+.landing-main section {
+  scroll-margin-top: 120px;
+}
+
 .landing-hero {
   position: relative;
   overflow: hidden;
@@ -677,12 +681,167 @@ a {
   font-weight: 600;
 }
 
-.landing-anchor {
-  height: 1px;
-  width: 100%;
+.landing-testimonials {
+  padding: clamp(3.5rem, 8vw, 6rem) 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.02), rgba(28, 78, 216, 0.05));
+}
+
+.landing-testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.landing-testimonial-card {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2.25rem 2rem;
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  background: var(--landing-surface-color);
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.08);
+}
+
+.landing-testimonial-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(28, 78, 216, 0.08), transparent 55%);
+  pointer-events: none;
+}
+
+.landing-testimonial-stars {
+  font-size: 1.25rem;
+  letter-spacing: 0.2em;
+  color: var(--landing-accent-color);
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+.landing-testimonial-quote {
   margin: 0;
-  padding: 0;
-  scroll-margin-top: 120px;
+  color: var(--landing-secondary-color);
+  font-size: 1.05rem;
+  line-height: 1.7;
+  font-style: italic;
+  position: relative;
+  z-index: 1;
+}
+
+.landing-testimonial-author {
+  margin: 0;
+  font-weight: 600;
+  color: var(--landing-muted-text);
+  position: relative;
+  z-index: 1;
+}
+
+.landing-faq {
+  padding: clamp(3.5rem, 8vw, 6rem) 0;
+  background: var(--landing-surface-color);
+}
+
+.landing-faq-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.landing-faq-item {
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.8), #ffffff);
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08);
+  padding: 0 1.75rem;
+}
+
+.landing-faq-item summary {
+  cursor: pointer;
+  list-style: none;
+  font-weight: 600;
+  color: var(--landing-secondary-color);
+  font-size: 1.05rem;
+  padding: 1.5rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.landing-faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.landing-faq-item summary::after {
+  content: '+';
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--landing-primary-color);
+  transition: transform 0.2s ease;
+}
+
+.landing-faq-item[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.landing-faq-item p {
+  margin: 0 0 1.5rem;
+  color: var(--landing-muted-text);
+  line-height: 1.7;
+}
+
+.landing-cta-final {
+  padding: clamp(3.5rem, 8vw, 6rem) 0 clamp(4rem, 8vw, 6.5rem);
+  background: radial-gradient(circle at top left, rgba(28, 78, 216, 0.16), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.04), rgba(15, 23, 42, 0));
+}
+
+.landing-cta-content {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(28, 78, 216, 0.92));
+  color: #ffffff;
+  border-radius: 32px;
+  padding: clamp(2.5rem, 6vw, 3.5rem);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.22);
+}
+
+.landing-cta-content h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.landing-cta-content p {
+  margin: 0 auto;
+  max-width: 42rem;
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.landing-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.landing-cta-content .landing-button-outline {
+  background: transparent;
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.landing-cta-content .landing-button-outline:hover,
+.landing-cta-content .landing-button-outline:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.6);
+  color: #ffffff;
 }
 
   @media (max-width: 1024px) {
@@ -707,6 +866,10 @@ a {
     }
 
     .landing-pricing-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .landing-testimonials-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
@@ -757,6 +920,10 @@ a {
   .landing-pricing-grid {
     grid-template-columns: 1fr;
   }
+
+  .landing-testimonials-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 600px) {
@@ -790,6 +957,14 @@ a {
 
   .landing-pricing-card {
     padding: 2.2rem 1.6rem;
+  }
+
+  .landing-testimonial-card {
+    padding: 2rem 1.65rem;
+  }
+
+  .landing-faq-item {
+    padding: 0 1.25rem;
   }
 
   .landing-hero-proof {

--- a/templates/landing/base.html
+++ b/templates/landing/base.html
@@ -271,8 +271,91 @@
           </div>
         </div>
       </section>
-      <div id="faq" class="landing-anchor" aria-hidden="true"></div>
-      <div id="cta-final" class="landing-anchor" aria-hidden="true"></div>
+      <section id="testimonials" class="landing-testimonials" aria-labelledby="testimonials-heading">
+        <div class="landing-section-inner">
+          <div class="landing-section-header">
+            <p class="landing-section-eyebrow">Referencje</p>
+            <h2 id="testimonials-heading">Opinie naszych klientów</h2>
+            <p class="landing-section-description">
+              Właściciele łodzi, quadów i kamperów doceniają elastyczność odbiorów oraz spokój, jaki daje im oddanie sprzętu w nasze ręce.
+            </p>
+          </div>
+          <div class="landing-testimonials-grid">
+            <article class="landing-testimonial-card" aria-label="Opinia klientki Anny">
+              <div class="landing-testimonial-stars" aria-label="Ocena 5 na 5">
+                <span aria-hidden="true">★★★★★</span>
+              </div>
+              <p class="landing-testimonial-quote">
+                „Po oddaniu łodzi do Schowane.pl przestałam martwić się o zimowanie. Wiosną czeka na mnie przygotowana do wodowania, a ja oszczędzam czas i nerwy.”
+              </p>
+              <p class="landing-testimonial-author">Anna, właścicielka łodzi motorowej</p>
+            </article>
+            <article class="landing-testimonial-card" aria-label="Opinia klienta Marcina">
+              <div class="landing-testimonial-stars" aria-label="Ocena 5 na 5">
+                <span aria-hidden="true">★★★★★</span>
+              </div>
+              <p class="landing-testimonial-quote">
+                „Magazyn jest świetnie zabezpieczony, a zespół reaguje błyskawicznie, kiedy potrzebuję wyciągnąć quada na spontaniczny wyjazd.”
+              </p>
+              <p class="landing-testimonial-author">Marcin, miłośnik wypraw off-road</p>
+            </article>
+            <article class="landing-testimonial-card" aria-label="Opinia klienta Ewy i Pawła">
+              <div class="landing-testimonial-stars" aria-label="Ocena 5 na 5">
+                <span aria-hidden="true">★★★★★</span>
+              </div>
+              <p class="landing-testimonial-quote">
+                „Zestaw narciarski i camper wracają w idealnym stanie. Doceniamy raporty serwisowe i możliwość transportu pod dom.”
+              </p>
+              <p class="landing-testimonial-author">Ewa i Paweł, rodzina podróżników</p>
+            </article>
+          </div>
+        </div>
+      </section>
+      <section id="faq" class="landing-faq" aria-labelledby="faq-heading">
+        <div class="landing-section-inner">
+          <div class="landing-section-header">
+            <p class="landing-section-eyebrow">FAQ</p>
+            <h2 id="faq-heading">Najczęściej zadawane pytania</h2>
+            <p class="landing-section-description">
+              Zebraliśmy odpowiedzi na kluczowe pytania dotyczące przechowywania sprzętu w Schowane.pl.
+            </p>
+          </div>
+          <div class="landing-faq-items" role="list">
+            <details class="landing-faq-item">
+              <summary>Jak wygląda proces odbioru sprzętu?</summary>
+              <p>
+                Po rezerwacji kontaktujemy się w celu potwierdzenia szczegółów i terminu odbioru. Nasza ekipa przyjeżdża specjalistycznym transportem lub przygotowuje stanowisko w magazynie, jeśli wolisz dostarczyć sprzęt samodzielnie.
+              </p>
+            </details>
+            <details class="landing-faq-item">
+              <summary>Czy mogę odwiedzać magazyn w trakcie przechowywania?</summary>
+              <p>
+                Tak, wystarczy wcześniejsze zgłoszenie wizyty. Dostęp jest możliwy 7 dni w tygodniu, a nasi pracownicy pomagają w przygotowaniu sprzętu do odbioru.
+              </p>
+            </details>
+            <details class="landing-faq-item">
+              <summary>Jakie dodatkowe usługi serwisowe oferujecie?</summary>
+              <p>
+                Wykonujemy przeglądy kontrolne, ładowanie akumulatorów, detailing oraz przygotowanie sprzętu do sezonu. Na życzenie organizujemy również transport na miejsce wypoczynku.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+      <section id="cta-final" class="landing-cta-final" aria-labelledby="cta-final-heading">
+        <div class="landing-section-inner">
+          <div class="landing-cta-content">
+            <h2 id="cta-final-heading">Gotowy odzyskać przestrzeń i spokój?</h2>
+            <p>
+              Zarezerwuj miejsce w magazynie Schowane.pl i powierz logistykę specjalistom. Przygotujemy indywidualną ofertę i zaplanujemy dogodny termin odbioru.
+            </p>
+            <div class="landing-cta-actions">
+              <a class="landing-button landing-button-primary" href="mailto:rezerwacje@schowane.pl">Zarezerwuj termin</a>
+              <a class="landing-button landing-button-outline" href="tel:+48123456789">Porozmawiaj z doradcą</a>
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
     {% endblock %}
     <script src="{{ url_for('static', filename='js/landing.js') }}" defer></script>

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -16,3 +16,6 @@ def test_landing_route_returns_success(client):
     assert "Rezerwujesz i umawiasz odbiór" in html
     assert "Elastyczne pakiety dopasowane do Twojego sprzętu" in html
     assert "Mały sprzęt" in html
+    assert "Opinie naszych klientów" in html
+    assert "Najczęściej zadawane pytania" in html
+    assert "Gotowy odzyskać przestrzeń i spokój?" in html


### PR DESCRIPTION
## Summary
- add testimonial, FAQ, and closing CTA sections to the landing page template
- style the new sections and adjust spacing utilities for smooth scroll behavior
- extend the landing page regression test to cover the new content

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e66f3c1d84832dbbf2dd60cd05146a